### PR TITLE
FIX #94, FIX #93 Jcenter() is decrecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Update your `build.gradle` (project path) like below :
 ```groovy
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 ```


### PR DESCRIPTION
After February 1st, 2022 jcenter() will not work anymore.

We have to use mavenCentrel() with specific Package repository URL, in our case it is: jitpack.io